### PR TITLE
Support for forms with Django 1.6

### DIFF
--- a/password_policies/forms/__init__.py
+++ b/password_policies/forms/__init__.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
 
 from django import forms
-from django.contrib.auth.hashers import UNUSABLE_PASSWORD
+try:
+    from django.contrib.auth.hashers import UNUSABLE_PASSWORD
+except ImportError:
+    from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User
 from django.contrib.sites.models import get_current_site


### PR DESCRIPTION
The readme claims 1.5 and upper support, however django 1.6 seems
to break an import in `forms/__init__.py`

See The "unusable_password" modifications bullet under [the release notes](https://docs.djangoproject.com/en/dev/releases/1.6/#miscellaneous)
