### PR TITLE
Made PasswordResetForm compatible with Django 1.6

### DIFF
--- a/password_policies/forms/__init__.py
+++ b/password_policies/forms/__init__.py
@@ -1,10 +1,7 @@
 from __future__ import unicode_literals
 
 from django import forms
-try:
-    from django.contrib.auth.hashers import UNUSABLE_PASSWORD
-except ImportError:
-    from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
+from django.contrib.auth.hashers import is_password_usable
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.forms import AdminPasswordChangeForm
 from django.contrib.auth.models import User
@@ -187,7 +184,7 @@ Validates that an active user exists with the given email address.
                                                is_active=True)
         if not len(self.users_cache):
             raise forms.ValidationError(self.error_messages['unknown'])
-        if any((user.password == UNUSABLE_PASSWORD)
+        if any(not is_password_usable(user.password)
                for user in self.users_cache):
             raise forms.ValidationError(self.error_messages['unusable'])
         return email

--- a/password_policies/tests/forms.py
+++ b/password_policies/tests/forms.py
@@ -2,6 +2,7 @@ from django.utils.encoding import force_unicode
 
 from password_policies.forms import PasswordPoliciesForm
 from password_policies.forms import PasswordPoliciesChangeForm
+from password_policies.forms import PasswordResetForm
 from password_policies.forms.fields import PasswordPoliciesField
 
 from password_policies.tests.lib import BaseTest
@@ -116,4 +117,26 @@ class PasswordPoliciesChangeFormTest(BaseTest):
                 'new_password1': 'Chah+pher9k',
                 'new_password2': 'Chah+pher9k'}
         form = PasswordPoliciesChangeForm(self.user, data)
+        self.assertTrue(form.is_valid())
+
+
+class PasswordResetFormTest(BaseTest):
+
+    def setUp(self):
+        self.user = create_user()
+        return super(PasswordResetFormTest, self).setUp()
+
+    def test_unusable_password(self):
+        self.user.set_unusable_password()
+        self.user.save()
+        data = {'email': self.user.email}
+        form = PasswordResetForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form["email"].errors,
+                         [force_unicode(form.error_messages['unusable'])])
+        self.assertFalse(form.is_valid())
+
+    def test_success(self):
+        data = {'email': self.user.email}
+        form = PasswordResetForm(data)
         self.assertTrue(form.is_valid())

--- a/password_policies/tests/lib.py
+++ b/password_policies/tests/lib.py
@@ -49,8 +49,8 @@ class BaseTest(TestCase):
         return super(BaseTest, self).tearDown()
 
 
-def create_user(username="alice", raw_password=None, date_joined=None,
-                last_login=None, commit=True):
+def create_user(username="alice", email="alice@example.com", raw_password=None,
+                date_joined=None, last_login=None, commit=True):
     """ Creates a non-staff user with dynamically generated properties.
 
 This function dynamically creates an user with following properties:
@@ -68,7 +68,7 @@ This function dynamically creates an user with following properties:
         date_joined = get_datetime_from_delta(timezone.now(), seconds)
     if not last_login:
         last_login = date_joined
-    user = User(username=username, is_active=True,
+    user = User(username=username, email=email, is_active=True,
                 last_login=last_login, date_joined=date_joined)
     user.set_password(raw_password)
     if commit:


### PR DESCRIPTION
Django 1.6 changed the way unusable passwords work. Part of this included the removal of the UNUSABLE_PASSWORD variable. This was handled by importing UNUSABLE_PASSWORD_PREFIX when UNUSABLE_PASSWORD was unavailable. The problem is that PasswordResetForm's clean_email method still contains a reference to UNUSABLE_PASSWORD, which would be undefined when using Django 1.6, leading to a NameError on form validation.

My solution uses the is_password_usable function, which is defined in both Django 1.5 and 1.6 (and earlier). I've written tests to verify that PasswordResetForm correctly handles usable and unusable passwords.
