### PR TITLE
Remove upper limit on Django version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ and a mechanism to force password changes.
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Utilities'
     ],
-    install_requires=['django>=1.5,<=1.6.2',
+    install_requires=['django>=1.5',
                       'django-easysettings',
     ],
     test_suite='tests.main',


### PR DESCRIPTION
`django-password-policies` claims " Django 1.5 or newer " then limits Django versions to `<=1.6.2`. Remove limitation and provide additional support for Django 1.7 as needed. (I haven't provided any Django 1.7 support yet but can do so if needed and/or desired.)
