### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ and a mechanism to force password changes.
     ],
     install_requires=['django>=1.5',
                       'django-easysettings',
+                      'pytz',
     ],
     test_suite='tests.main',
 )


### PR DESCRIPTION
install_requires `pytz` should fix:

```
ImproperlyConfigured at /admin/password_policies/passwordhistory/

This query requires pytz, but it isn't installed.

```
