### PR TITLE
Fix for #41, middleware compatible with prefixed URLs

### DIFF
--- a/password_policies/middleware.py
+++ b/password_policies/middleware.py
@@ -140,7 +140,7 @@ To use this middleware you need to add it to the
         if request.method != 'GET':
             return
         try:
-            resolve(request.path)
+            resolve(request.path_info)
         except Resolver404:
             return
         self.now = timezone.now()


### PR DESCRIPTION
Please find the pull request for the small bugfix in the middleware. (issue #41 ) 

This bugfix allows the middleware to correctly resolve all URLs if the site is deployed with an URL prefix.