### PR TITLE
Corrected debian package in install docs

### DIFF
--- a/docs/topics/install.rst
+++ b/docs/topics/install.rst
@@ -29,7 +29,7 @@ the `Python bindings for cracklib`_ need to be installed.
 On most linux distros it can simply be installed via a package manager. On
 Debian based distributions the according package is called:
 
-* python-crack
+* python-cracklib
 
 .. _install-levenshtein:
 


### PR DESCRIPTION
The debian package for the python crack bindings seems to be python-cracklib not python-crack 

https://packages.debian.org/search?keywords=python-crack&searchon=names&suite=stable&section=all

Changed the reference to python-crack to python-cracklib in install.rst