### PR TITLE
Clone settings path list

### DIFF
--- a/password_policies/middleware.py
+++ b/password_policies/middleware.py
@@ -97,7 +97,7 @@ To use this middleware you need to add it to the
             request.session[self.required] = False
 
     def _is_excluded_path(self, actual_path):
-        paths = settings.PASSWORD_CHANGE_MIDDLEWARE_EXCLUDED_PATHS
+        paths = settings.PASSWORD_CHANGE_MIDDLEWARE_EXCLUDED_PATHS[:]
         path = r'^%s$' % self.url
         paths.append(path)
         media_url = settings.MEDIA_URL


### PR DESCRIPTION
It looks like each time that _is_excluded_path is called that the module-level PASSWORD_CHANGE_MIDDLEWARE_EXCLUDED_PATHS list will be appended to (via the paths alias) causing it to grow over time.