### PR TITLE
Fixes PasswordChangeMiddleware deprecation issues for Django 1.10

### DIFF
--- a/password_policies/middleware.py
+++ b/password_policies/middleware.py
@@ -4,13 +4,14 @@ from django.core.urlresolvers import resolve, reverse, NoReverseMatch, \
     Resolver404
 from django.http import HttpResponseRedirect
 from django.utils import timezone
+from django.utils.deprecation import MiddlewareMixin
 
 from password_policies.conf import settings
 from password_policies.models import PasswordChangeRequired, PasswordHistory
 from password_policies.utils import PasswordCheck
 
 
-class PasswordChangeMiddleware(object):
+class PasswordChangeMiddleware(MiddlewareMixin):
     """
 A middleware to force a password change.
 
@@ -28,6 +29,17 @@ To use this middleware you need to add it to the
 ``MIDDLEWARE_CLASSES`` list in a project's settings::
 
     MIDDLEWARE_CLASSES = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'password_policies.middleware.PasswordChangeMiddleware',
+        # ... other middlewares ...
+    )
+
+or ``MIDDLEWARE`` list if using Django 1.10 or higher
+
+    MIDDLEWARE = (
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
Changes in Django 1.10 middleware stuff now means password_policies.middleware.PasswordChangeMiddleware is now broken.

[https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware)

Small change here fixes it. 