### PR TITLE
Fixed url patterns which are removed in django 1.10

### DIFF
--- a/password_policies/urls.py
+++ b/password_policies/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from password_policies.views import PasswordChangeFormView
 from password_policies.views import PasswordChangeDoneView
@@ -7,24 +7,23 @@ from password_policies.views import PasswordResetConfirmView
 from password_policies.views import PasswordResetFormView
 from password_policies.views import PasswordResetDoneView
 
-
-urlpatterns = patterns('',
-                       url(r'^change/done/$',
-                           PasswordChangeDoneView.as_view(),
-                           name="password_change_done"),
-                       url(r'^change/$',
-                           PasswordChangeFormView.as_view(),
-                           name="password_change"),
-                       url(r'^reset/$',
-                           PasswordResetFormView.as_view(),
-                           name="password_reset"),
-                       url(r'^reset/complete/$',
-                           PasswordResetCompleteView.as_view(),
-                           name="password_reset_complete"),
-                       url(r'^reset/confirm/([0-9A-Za-z_\-]+)/([0-9A-Za-z]{1,13})/([0-9A-Za-z-=_]{1,32})/$',
-                           PasswordResetConfirmView.as_view(),
-                           name="password_reset_confirm"),
-                       url(r'^reset/done/$',
-                           PasswordResetDoneView.as_view(),
-                           name="password_reset_done"),
-                       )
+urlpatterns = [
+    url(r'^change/done/$',
+        PasswordChangeDoneView.as_view(),
+        name="password_change_done"),
+    url(r'^change/$',
+        PasswordChangeFormView.as_view(),
+        name="password_change"),
+    url(r'^reset/$',
+        PasswordResetFormView.as_view(),
+        name="password_reset"),
+    url(r'^reset/complete/$',
+        PasswordResetCompleteView.as_view(),
+        name="password_reset_complete"),
+    url(r'^reset/confirm/([0-9A-Za-z_\-]+)/([0-9A-Za-z]{1,13})/([0-9A-Za-z-=_]{1,32})/$',
+        PasswordResetConfirmView.as_view(),
+        name="password_reset_confirm"),
+    url(r'^reset/done/$',
+        PasswordResetDoneView.as_view(),
+        name="password_reset_done"),
+]

--- a/password_policies/views.py
+++ b/password_policies/views.py
@@ -78,7 +78,9 @@ A view that allows logged in users to change their password.
         form.save()
         return super(PasswordChangeFormView, self).form_valid(form)
 
-    def get_form(self, form_class):
+    def get_form(self, form_class=None):
+        if form_class is None:
+            form_class = self.get_form_class()
         return form_class(self.request.user, **self.get_form_kwargs())
 
     def get_success_url(self):
@@ -184,7 +186,9 @@ class PasswordResetConfirmView(LoggedOutMixin, FormView):
         kwargs['validlink'] = self.validlink
         return super(PasswordResetConfirmView, self).get_context_data(**kwargs)
 
-    def get_form(self, form_class):
+    def get_form(self, form_class=None):
+        if form_class is None:
+            form_class = self.get_form_class()
         return form_class(self.user, **self.get_form_kwargs())
 
     def get_success_url(self):


### PR DESCRIPTION
There is import of _django.conf.urls.patterns_ in https://github.com/tarak/django-password-policies/blob/master/password_policies/urls.py on line #1 that is deprecated from Django 1.8 and removed in Django 1.10 .
Import of _django.conf.urls.patterns_ causes "ImportError: cannot import name 'patterns'"

**Django 1.10 release notes:**
https://docs.djangoproject.com/en/1.10/releases/1.10/#features-removed-in-1-10
django.conf.urls.patterns() is removed.

Django 1.10 use simple list for url patterns.